### PR TITLE
Add install instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,33 @@ sudo apt install yarnpkg
 ```
 
 - Verify that yarn is installed by running `yarn --version`. The yarn version (e.g. 1.17.3) should be returned.
+
+## Arch Linux
+
+### Visual Studio Code
+
+- Run the following command in the terminal
+
+```
+pacman -S code
+```
+
+### Node.js
+
+- Run the following command in the terminal
+
+```
+pacman -S nodejs
+```
+
+- Verify that node is installed by running `node --version`. The node version (e.g. v13.10.0) should be returned.
+
+### Yarn
+
+- Run the following command in the terminal
+
+```
+pacman -S yarn
+```
+
+- Verify that yarn is installed by running `yarn --version`. The yarn version (e.g. v1.22.0) should be returned.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,33 @@ brew install yarn
 ```
 
 - Verify that yarn is installed by running `yarn --version`. The yarn version (e.g. v1.22.0) should be returned.
+
+## Ubuntu
+
+### Visual Studio Code
+
+- Run the following command in the terminal
+
+```
+sudo snap install code --classic
+```
+
+### Node.js
+
+- Run the following command in the terminal
+
+```
+sudo snap install node --classic --edge
+```
+
+- Verify that node is installed by running `node --version`. The node version (e.g. v13.0.0-nightly20190802452b393c1f) should be returned.
+
+### Yarn
+
+- Run the following command in the terminal
+
+```
+sudo apt install yarnpkg
+```
+
+- Verify that yarn is installed by running `yarn --version`. The yarn version (e.g. 1.17.3) should be returned.


### PR DESCRIPTION
Note that the versions of the software available on Ubuntu may not
be the same as that used for Windows and macOS. See contents of
README.md for more information.